### PR TITLE
fix: include configured model name in CustomModel chat requests

### DIFF
--- a/lib/bloc/ui_bloc/ui_state.dart
+++ b/lib/bloc/ui_bloc/ui_state.dart
@@ -212,6 +212,7 @@ Models? _modelFromConfig(Map<String, dynamic> modelConfig) {
 
       return CustomModel(
         url: url,
+        model: modelName,
         httpMethod: (modelConfig['httpMethod'] ?? 'POST').toString(),
         toolCallingMethod: parseToolCallingMethod(
           modelConfig['toolCallingMethod'],

--- a/lib/utils/ai.dart
+++ b/lib/utils/ai.dart
@@ -949,7 +949,7 @@ class CustomModel extends Models {
   @override
   String? get apiKey => null;
   @override
-  String? get model => null;
+  final String? model;
   final String httpMethod;
   final Map<String, String> customHeaders;
   final Map<String, dynamic> Function(String code, String instruction)?
@@ -963,6 +963,7 @@ class CustomModel extends Models {
     required this.customParser,
     this.httpMethod = 'POST',
     this.toolCallingMethod = ToolCallingMethod.openAiCompatible,
+    this.model,
   });
 
   @override


### PR DESCRIPTION
## Summary

Fixes #32. AI chat failed for **Custom (OpenAI-compatible)** providers with `Model {{model}} is not supported` because `CustomModel` hardcoded its `model` getter to `null`:

- `lib/utils/ai.dart` — `CustomModel` had `String? get model => null;`, so chat requests serialized `"model": null` and tool-calling requests omitted `model` entirely.
- `lib/ui/widgets.dart` — chat `_buildRequestBody` / title generation send `"model": chatModel.model` (→ null).

Code completion already worked because its `requestBuilder` built the payload directly from config with the model name.

## Changes

1. **`lib/utils/ai.dart`** — `CustomModel` now takes an optional `model` field (constructor param) instead of returning `null` from the getter.
2. **`lib/bloc/ui_bloc/ui_state.dart`** — pass `model: modelName` (already in scope) when constructing `CustomModel` in `_modelFromConfig`.

No other call sites need changes: `"model": chatModel.model` in `widgets.dart` and the `if (model != null)` guard in `buildToolCallingRequest` now pick up the real name automatically.

## Testing

- Verified with `curl` that the fixed request shape (`"model": "deepseek-v4-flash-free"` + `messages`) succeeds against an OpenAI-compatible endpoint (OpenCode Zen), while the old shape (`"model": null`) returns `Model {{model}} is not supported`.
- I don't have a Flutter/Android build environment locally, so I couldn't run the app end-to-end — this small change would benefit from a maintainer/CI check.

## PR note

This PR contains only the fix. A separate build workflow (APK artifact) lives on my fork's `test/apk-build` branch and is intentionally **not** part of this PR.
